### PR TITLE
Add cosmos genesis tinker script with example

### DIFF
--- a/cosmos-genesis-tinker/README.md
+++ b/cosmos-genesis-tinker/README.md
@@ -1,5 +1,8 @@
 # Cosmos Genesis Tinker
 
+You can get more docs by invoking `pydoc3 cosmos_genesis_tinker`.
+TODO: Add the output to the README or it's own .md file
+
 ## API
 
 Tinkering with genesis files

--- a/cosmos-genesis-tinker/README.md
+++ b/cosmos-genesis-tinker/README.md
@@ -1,0 +1,25 @@
+# Cosmos Genesis Tinker
+
+## API
+
+Tinkering with genesis files
+
+```python
+import cosmos_genesis_tinker
+
+genesis = cosmos_genesis_tinker.GenesisTinker()
+
+genesis.load_file(file)
+genesis.save_file(file)
+old  = {
+"pub_key": "",
+"address": "",
+"consensus_address": ""
+}
+genesis.swap_validator(old, new)
+genesis.swap_delegator(old_adddress, new_address)
+genesis.increase_balance(address, increase=300000000, denom="uatom")
+genesis.increase_validator_power(validator_address, power_increase=DEFAULT_POWER)
+genesis.increase_validator_stake(operator_address, increase=DEFAULT_POWER*POWER_TO_TOKENS)
+genesis.increase_delegator_stake(delegator_address, increase=DEFAULT_POWER*POWER_TO_TOKENS)
+```

--- a/cosmos-genesis-tinker/cosmos_genesis_tinker.py
+++ b/cosmos-genesis-tinker/cosmos_genesis_tinker.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+
+"""
+This module helps you configure Cosmos Chain genesis files for testnets.
+TODO: Docs for how to get a genesis file
+"""
+
+import json
+from hashlib import sha256
+from zipfile import ZipFile
+from io import BytesIO
+import gzip
+import tarfile
+import requests
+
+BINANCE_VALIDATOR_ADDRESS = "cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf"
+BINANCE_TOKEN_BONDING_POOL_ADDRESS = "cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh"
+
+DEFAULT_POWER = 6000000000
+POWER_TO_TOKENS = 1000000
+
+
+class GenesisTinker:
+    """
+    This class gives you primitives for tinkering with Cosmos chain Genesis Files
+    """
+    genesis = {}
+
+    def load_file(self, path):
+        """
+        Loads a genesis file from the given path
+        """
+
+        with open(path, "r", encoding="utf8") as file:
+            content = file.read()
+            file.close()
+            self.genesis = json.load(content)
+        return self
+
+    def load_url(self, url, shasum=False):
+        """
+        Download and parse a genesis file from the web.
+        Optionally specify a sha256 sum to verify the data integrity
+        The genesis file can also be stored in a zip file under `genesis.json`
+        """
+        request = requests.get(url, allow_redirects=True, stream=True)
+
+        # Auto-read from zipfiles
+        if '.tar.gz' in url:
+            with tarfile.open(fileobj=request.raw, mode='r|gz') as archive:
+                archive.list()
+                with archive.extractfile('genesis.json') as file:
+                    content = file.read()
+        elif '.gz' in url:
+            with gzip.open(request.raw, 'r') as file:
+                content = file.read()
+        elif '.zip' in url:
+            with ZipFile(BytesIO(request.content), 'r') as archive:
+                with archive.open('genesis.json', 'r') as file:
+                    content = file.read()
+        else:
+            content = request.content
+
+        if shasum is not False:
+            got_digest = sha256(content).hexdigest()
+            if got_digest != shasum:
+                raise Exception(
+                    "Got invalid digest from remote file", got_digest, shasum)
+
+        self.genesis = json.loads(content)
+
+        return self
+
+    def generate_json(self):
+        """
+        Generates the JSON for the current genesis state
+        """
+        return json.dumps(self.genesis, indent=False)
+
+    def generate_shasum(self):
+        """
+        Generates a sha256 checksum of the genesis file (to verify later)
+        """
+        content = self.generate_json()
+        content_bytes = content.encode('utf-8')
+        return sha256(content_bytes).hexdigest()
+
+    def save_file(self, path):
+        """
+        Save a modified genesis file back to JSON
+        """
+        with open(path, "w", encoding="utf8") as file:
+            json.dump(self.genesis, file, indent=False)
+        return self
+
+    def swap_validator(self, old, new):
+        """
+        Swaps out an existing validator with a new one
+
+        `old` and `new` should contain the properties `pub_key`, `address`, and `consensus_address`
+        e.g.
+
+        old = {
+            "pub_key" : "Whatever",
+            "address": "Something",
+            "consensus_address": "cosmosvalcon..."
+        }
+        """
+        staking_validators = self.genesis["app_state"]["staking"]["validators"]
+        validators = self.genesis["validators"]
+        missed_blocks = self.genesis["app_state"]["slashing"]["missed_blocks"]
+        signing_infos = self.genesis["app_state"]["slashing"]["signing_infos"]
+
+        found_validator = False
+        for validator in validators:
+            if validator["pub_key"]["value"] == old["pub_key"]:
+                found_validator = True
+                validator["pub_key"]["value"] = new["pub_key"]
+                if validator["address"] != old["address"]:
+                    raise Exception(
+                        "Old address doesn't match old pub key")
+                validator["address"] = new["address"]
+
+        if not found_validator:
+            raise Exception("Could not find validator")
+
+        found_validator = False
+        for validator in staking_validators:
+            if validator["consensus_pubkey"]["key"] == old["pub_key"]:
+                validator["consensus_pubkey"]["key"] = new["pub_key"]
+                found_validator = True
+                break
+
+        if not found_validator:
+            raise Exception("Could not find validator staking")
+
+        found_validator = False
+        for validator in missed_blocks:
+            if validator["address"] == old["consensus_address"]:
+                validator["address"] = new["address"]
+                found_validator = True
+                break
+
+        if not found_validator:
+            raise Exception("Could not find validator in missed blocks")
+
+        found_validator = False
+        for validator in signing_infos:
+            if validator["address"] == old["consensus_address"]:
+                validator["address"] = new["address"]
+                found_validator = True
+                break
+
+        if not found_validator:
+            raise Exception("Could not find validator in signing infos")
+
+        return self
+
+    def swap_delegator(self, old_address, new_address):
+        """
+        Swaps out an exsiting delegator with a new one
+        """
+
+        accounts = self.genesis["app_state"]["auth"]["accounts"]
+        balances = self.genesis["app_state"]["bank"]["balances"]
+        delegations = self.genesis["app_state"]["staking"]["delegations"]
+        starting_infos = self.genesis["app_state"]["distribution"]["delegator_starting_infos"]
+
+        found_account = False
+        for account in accounts:
+            try:
+                if account["address"] == old_address:
+                    account["address"] = new_address
+                    found_account = True
+                    break
+            except KeyError:
+                pass
+
+        if not found_account:
+            raise Exception("Could not find old account address")
+
+        found_balance = False
+        for balance in balances:
+            if balance["address"] == old_address:
+                balance["address"] = new_address
+                found_balance = True
+                break
+
+        if not found_balance:
+            raise Exception('Could not find old balance')
+
+        found_delegation = False
+        for delegation in delegations:
+            if delegation["delegator_address"] == old_address:
+                delegation["delegator_address"] = new_address
+                found_delegation = True
+                break
+
+        if not found_delegation:
+            raise Exception("Could not find old delegator stake")
+
+        for info in starting_infos:
+            if info["delegator_address"] == old_address:
+                info["delegator_address"] = new_address
+                break
+
+        return self
+
+    def create_coin(self, denom, amount="0"):
+        """
+        Creats a new coin based on a given name if it doesn't exist
+        """
+
+        supplies = self.genesis["app_state"]["bank"]["supply"]
+
+        for supply in supplies:
+            if supply['denom'] == denom:
+                # Already exists, so we don't need to add it
+                return self
+
+        supplies.append({"denom": denom, "amount": amount})
+
+        return self
+
+    def increase_balance(self, address, increase=300000000, denom="uatom"):
+        """
+        Increases the balance of a person and also the overall supply of uatom
+        """
+
+        balances = self.genesis["app_state"]["bank"]["balances"]
+
+        found_balance = False
+        for balance in balances:
+            if balance["address"] == address:
+                found_balance = True
+                had_coin = False
+                for coin in balance["coins"]:
+                    if coin["denom"] == denom:
+                        old_amount = int(coin["amount"])
+                        new_amount = old_amount + increase
+                        coin["amount"] = str(new_amount)
+                        had_coin = True
+                        break
+                if not had_coin:
+                    balance["coins"].append(
+                        {"denom": denom, "amount": str(increase)})
+                break
+
+        if not found_balance:
+            raise Exception('Could not find balance for address')
+
+        self.increase_supply(increase, denom)
+        return self
+
+    def increase_supply(self, increase, denom="uatom"):
+        """
+        Increase the total supply of coins of a given denomination
+        """
+
+        supplies = self.genesis["app_state"]["bank"]["supply"]
+
+        found_coin = False
+        for coin in supplies:
+            if coin["denom"] == denom:
+                old_amount = int(coin["amount"])
+                new_amount = old_amount + increase
+                coin["amount"] = str(new_amount)
+                found_coin = True
+                break
+
+        if not found_coin:
+            self.create_coin(denom, increase)
+
+        return self
+
+    def increase_validator_power(self, validator_address, power_increase=DEFAULT_POWER):
+        """
+        Increase the staking power of a validator
+        Also increases the last total power value
+        """
+        validators = self.genesis['validators']
+
+        found_validator = False
+
+        for validator in validators:
+            if validator["address"] == validator_address:
+                old_power = int(validator["power"])
+                new_power = old_power + power_increase
+                validator["power"] = str(new_power)
+                found_validator = True
+                break
+
+        if not found_validator:
+            raise Exception('Could not find validator_address')
+
+        last_total_power = int(
+            self.genesis['app_state']['staking']['last_total_power'])
+        new_last_total_power = last_total_power + power_increase
+        self.genesis["app_state"]["staking"]["last_total_power"] = str(
+            new_last_total_power)
+
+        return self
+
+    def increase_validator_stake(self, operator_address, increase=DEFAULT_POWER*POWER_TO_TOKENS):
+        """
+        Increases the stake of a validator as well as its delegator_shares
+        """
+        staking_validators = self.genesis["app_state"]["staking"]["validators"]
+
+        found_validator = False
+        for validator in staking_validators:
+            if validator["operator_address"] == operator_address:
+                old_amount = int(validator["tokens"])
+                new_amount = old_amount + increase
+                validator["tokens"] = str(new_amount)
+
+                old_shares = float(validator["delegator_shares"])
+                new_shares = old_shares + increase
+                validator["delegator_address"] = str(
+                    format(new_shares, ".18f"))
+
+                found_validator = True
+                break
+
+        if not found_validator:
+            raise Exception("Could not find operator_address")
+
+        return self
+
+    def increase_delegator_stake(self, delegator_address, increase=DEFAULT_POWER*POWER_TO_TOKENS):
+        """
+        Increases the stake for a delegator
+        """
+        starting_infos = self.genesis["app_state"]["distribution"]["delegator_starting_infos"]
+
+        found_stake = False
+        for info in starting_infos:
+            if info["delegator_address"] == delegator_address:
+                old_stake = float(info["starting_info"]["stake"])
+                new_stake = old_stake + increase
+                info["starting_info"]["stake"] = str(
+                    format(new_stake, ".18f"))
+                found_stake = True
+                break
+
+        if not found_stake:
+            raise Exception("Unable to find delegator_address")
+
+        return self

--- a/cosmos-genesis-tinker/cosmos_genesis_tinker.py
+++ b/cosmos-genesis-tinker/cosmos_genesis_tinker.py
@@ -47,11 +47,13 @@ class GenesisTinker:
         """
 
         if not self.should_log_steps:
-            return
+            return -1
 
         self.__step_count += 1
         step_count = str(self.__step_count)
         print(step_count + ". " + message)
+
+        return step_count
 
     def load_file(self, path):
         """
@@ -131,6 +133,17 @@ class GenesisTinker:
 
         with open(path, "w", encoding="utf8") as file:
             json.dump(self.genesis, file, indent=False)
+
+        return self
+
+    def swap_chain_id(self, chain_id):
+        """
+        Swap the chain ID with your own name
+        """
+
+        self.log_step("Swapping chain id to " + chain_id)
+
+        self.genesis["chain_id"] = chain_id
 
         return self
 
@@ -414,3 +427,5 @@ class GenesisTinker:
         self.increase_delegator_stake(delegator, stake)
         self.increase_validator_stake(validator, stake)
         self.increase_validator_power(validator, stake)
+
+        return self

--- a/cosmos-genesis-tinker/cosmos_genesis_tinker.py
+++ b/cosmos-genesis-tinker/cosmos_genesis_tinker.py
@@ -209,7 +209,7 @@ class GenesisTinker:
 
     def create_coin(self, denom, amount="0"):
         """
-        Creats a new coin based on a given name if it doesn't exist
+        Creates a new coin based on a given name if it doesn't exist
         """
 
         supplies = self.genesis["app_state"]["bank"]["supply"]

--- a/cosmos-genesis-tinker/cosmos_genesis_tinker.py
+++ b/cosmos-genesis-tinker/cosmos_genesis_tinker.py
@@ -416,7 +416,7 @@ class GenesisTinker:
 
         return self
 
-    def increase_delegator_stake_to_validator(self, delegator, validator, stake, token_bonding_pool_address=TOKEN_BONDING_POOL_ADDRESS):  # pylint: disable=C0301
+    def increase_delegator_stake_to_validator(self, delegator, operator_address, validator_address, stake, power_to_tokens=POWER_TO_TOKENS, token_bonding_pool_address=TOKEN_BONDING_POOL_ADDRESS):  # pylint: disable=C0301
         """
         Increase a delegator's stake to a validator.
         Includes increasing token bonding pool balance and validator power
@@ -424,7 +424,7 @@ class GenesisTinker:
 
         self.increase_balance(token_bonding_pool_address, stake)
         self.increase_delegator_stake(delegator, stake)
-        self.increase_validator_stake(validator, stake)
-        self.increase_validator_power(validator, stake)
+        self.increase_validator_stake(operator_address, stake)
+        self.increase_validator_power(validator_address, stake/power_to_tokens)
 
         return self

--- a/cosmos-genesis-tinker/cosmos_genesis_tinker.py
+++ b/cosmos-genesis-tinker/cosmos_genesis_tinker.py
@@ -63,9 +63,8 @@ class GenesisTinker:
         self.log_step("Loading genesis from file " + path)
 
         with open(path, "r", encoding="utf8") as file:
-            content = file.read()
-            file.close()
-            self.genesis = json.load(content)
+            self.genesis = json.load(file)
+            file.close
         return self
 
     def load_url(self, url, shasum=False):

--- a/cosmos-genesis-tinker/cosmos_genesis_tinker.py
+++ b/cosmos-genesis-tinker/cosmos_genesis_tinker.py
@@ -14,7 +14,8 @@ import tarfile
 import requests
 
 BINANCE_VALIDATOR_ADDRESS = "cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf"
-BINANCE_TOKEN_BONDING_POOL_ADDRESS = "cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh"
+# Default value is the cosmoshub-4 bonded token pool account
+TOKEN_BONDING_POOL_ADDRESS = "cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh"
 
 DEFAULT_POWER = 6000000000
 POWER_TO_TOKENS = 1000000

--- a/cosmos-genesis-tinker/cosmos_genesis_tinker.py
+++ b/cosmos-genesis-tinker/cosmos_genesis_tinker.py
@@ -260,7 +260,7 @@ class GenesisTinker:
         Creates a new coin based on a given name if it doesn't exist
         """
 
-        self.log_step("Creating new coin " + denom + " valued at " + amount)
+        self.log_step("Creating new coin " + denom + " valued at " + str(amount))
 
         supplies = self.genesis["app_state"]["bank"]["supply"]
 

--- a/cosmos-genesis-tinker/genesis-example.py
+++ b/cosmos-genesis-tinker/genesis-example.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import sys
+import cosmos_genesis_tinker
+
+if len(sys.argv) == 1:
+    print(
+        'Usage: ./modify_genesis.py  [new_genesis.json] [exported_genesis.json]')
+    # sys.exit(1)
+
+exported_genesis_filename = False
+new_genesis_filename = False
+
+if len(sys.argv) > 1:
+    exported_genesis_filename = sys.argv[1]
+if len(sys.argv) > 2:
+    new_genesis_filename = sys.argv[2]
+
+# static values (for now, should be in .json config file)
+NODE1_OLD_PUBKEY = "cOQZvh/h9ZioSeUMZB/1Vy1Xo5x2sjrVjlE/qHnYifM="
+NODE1_OLD_ADDRESS = "B00A6323737F321EB0B8D59C6FD497A14B60938A"
+NODE1_NEW_PUBKEY = "qwiUMxz3llsy45fPvM0a8+XQeAJLvrX3QAEJmRMEEoU="
+NODE1_NEW_ADDRESS = "D5AB5E458FD9F9964EF50A80451B6F3922E6A4AA"
+NODE1_OLD_COSMOSVALCONS1 = "cosmosvalcons1kq9xxgmn0uepav9c6kwxl4yh599kpyu28e7ee6"
+NODE1_NEW_COSMOSVALCONS1 = "cosmosvalcons16k44u3v0m8uevnh4p2qy2xm08y3wdf92xsc3ve"
+
+NODE2_OLD_PUBKEY = "W459Kbdx+LJQ7dLVASW6sAfdqWqNRSXnvc53r9aOx/o="
+NODE2_OLD_ADDRESS = "83F47D7747B0F633A6BA0DF49B7DCF61F90AA1B0"
+NODE2_NEW_PUBKEY = "oi55Dw+JjLQc4u1WlAS3FsGwh5fd5/N5cP3VOLnZ/H0="
+NODE2_NEW_ADDRESS = "7CB07B94FD743E2A8520C2B50DA4B03740643BF5"
+NODE2_OLD_COSMOSVALCONS1 = "cosmosvalcons1s0686a68krmr8f46ph6fklw0v8us4gdsm7nhz3"
+NODE2_NEW_COSMOSVALCONS1 = "cosmosvalcons10jc8h98awslz4pfqc26smf9sxaqxgwl4vxpcrp"
+
+# user account for delegator (node2)
+OLD_DELEGATOR_ADDRESS = "cosmos1qq9ydrjeqalqa3zyqqtdczvuugsjlcc3c7x4d4"
+NEW_DELEGATOR_ADDRESS = "cosmos10aak94tfdl3pgt8qe6ga75qh3zkf3anpq8aqg0"
+OLD_DELEGATOR_KEY = "AjEkAHzQakRnyUppiM5/hnA6h2D7NkdxExxgiCG+NiDh"
+NEW_DELEGATOR_KEY = "A81DhG/5sB6RA8dl/6jtmX0svTc0xJL5NjPPI/q4jJWP"
+
+# binance val
+BINANCE_VALIDATOR_ADDRESS = "cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf"
+BINANCE_TOKEN_BONDING_POOL = "cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh"
+
+GENESIS_ARCHIVE = "https://github.com/cosmos/vega-test/blob/master/exported_unmodified_genesis.json.gz?raw=true"
+GENESIS_SHASUM = "86f29f23f9df51f5c58cb2c2f95e263f96f123801fc9844765f98eca49fe188f"
+
+genesis = cosmos_genesis_tinker.GenesisTinker()
+
+if exported_genesis_filename:
+    print("Loading file")
+    genesis.load_file(exported_genesis_filename)
+else:
+    print("Downloading file")
+    genesis.load_url(GENESIS_ARCHIVE, GENESIS_SHASUM)
+
+print("Tinkering")
+
+genesis.swap_validator({
+    "pub_key": NODE1_OLD_PUBKEY,
+    "address": NODE1_OLD_ADDRESS,
+    "consensus_address": NODE1_OLD_COSMOSVALCONS1
+}, {
+    "pub_key": NODE1_NEW_PUBKEY,
+    "address": NODE1_NEW_ADDRESS,
+    "consensus_address": NODE1_NEW_COSMOSVALCONS1
+})
+
+genesis.swap_validator({
+    "pub_key": NODE2_OLD_PUBKEY,
+    "address": NODE2_OLD_ADDRESS,
+    "consensus_address": NODE2_OLD_COSMOSVALCONS1
+}, {
+    "pub_key": NODE2_NEW_PUBKEY,
+    "address": NODE2_NEW_ADDRESS,
+    "consensus_address": NODE2_NEW_COSMOSVALCONS1
+})
+genesis.swap_delegator(OLD_DELEGATOR_ADDRESS, NEW_DELEGATOR_ADDRESS)
+
+genesis.increase_balance(NEW_DELEGATOR_ADDRESS, 300000000)
+
+genesis.increase_validator_power(NODE2_NEW_ADDRESS, 6000000000)
+
+STAKE_INCREASE = 6000000000000000
+genesis.increase_balance(BINANCE_TOKEN_BONDING_POOL, STAKE_INCREASE)
+genesis.increase_validator_stake(BINANCE_VALIDATOR_ADDRESS, STAKE_INCREASE)
+genesis.increase_delegator_stake(NEW_DELEGATOR_ADDRESS, STAKE_INCREASE)
+
+print("SHA256SUM:")
+print(genesis.generate_shasum())
+
+if new_genesis_filename:
+    print("Saving")
+    genesis.save_file(new_genesis_filename)

--- a/cosmos-genesis-tinker/genesis-example.py
+++ b/cosmos-genesis-tinker/genesis-example.py
@@ -78,12 +78,9 @@ genesis.swap_delegator(OLD_DELEGATOR_ADDRESS, NEW_DELEGATOR_ADDRESS)
 
 genesis.increase_balance(NEW_DELEGATOR_ADDRESS, 300000000)
 
-genesis.increase_validator_power(NODE2_NEW_ADDRESS, 6000000000)
-
 STAKE_INCREASE = 6000000000000000
-genesis.increase_balance(BINANCE_TOKEN_BONDING_POOL, STAKE_INCREASE)
-genesis.increase_validator_stake(BINANCE_VALIDATOR_ADDRESS, STAKE_INCREASE)
-genesis.increase_delegator_stake(NEW_DELEGATOR_ADDRESS, STAKE_INCREASE)
+genesis.increase_delegator_stake_to_validator(
+    NEW_DELEGATOR_ADDRESS, NODE2_NEW_ADDRESS, STAKE_INCREASE)
 
 print("SHA256SUM:")
 print(genesis.generate_shasum())

--- a/cosmos-genesis-tinker/genesis-example.py
+++ b/cosmos-genesis-tinker/genesis-example.py
@@ -12,9 +12,9 @@ exported_genesis_filename = False
 new_genesis_filename = False
 
 if len(sys.argv) > 1:
-    exported_genesis_filename = sys.argv[1]
+    new_genesis_filename = sys.argv[1]
 if len(sys.argv) > 2:
-    new_genesis_filename = sys.argv[2]
+    exported_genesis_filename = sys.argv[2]
 
 # static values (for now, should be in .json config file)
 NODE1_OLD_PUBKEY = "cOQZvh/h9ZioSeUMZB/1Vy1Xo5x2sjrVjlE/qHnYifM="
@@ -82,7 +82,7 @@ genesis.increase_balance(NEW_DELEGATOR_ADDRESS, 300000000)
 
 STAKE_INCREASE = 6000000000000000
 genesis.increase_delegator_stake_to_validator(
-    NEW_DELEGATOR_ADDRESS, NODE2_NEW_ADDRESS, STAKE_INCREASE)
+    NEW_DELEGATOR_ADDRESS, BINANCE_VALIDATOR_ADDRESS, NODE2_NEW_ADDRESS, STAKE_INCREASE)
 
 print("SHA256SUM:")
 print(genesis.generate_shasum())

--- a/cosmos-genesis-tinker/genesis-example.py
+++ b/cosmos-genesis-tinker/genesis-example.py
@@ -55,6 +55,8 @@ else:
 
 print("Tinkering")
 
+genesis.swap_chain_id("cosmos-genesis-tinker-example")
+
 genesis.swap_validator({
     "pub_key": NODE1_OLD_PUBKEY,
     "address": NODE1_OLD_ADDRESS,

--- a/cosmos-genesis-tinker/genesis-theta.py
+++ b/cosmos-genesis-tinker/genesis-theta.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+#### Addresses
+# hy-hydrogen self-delegation account cosmos1lapm2cq4qjrl4fm5xcftfhg245m63d30mswfjp
+# hy-hydrogen operator address cosmosvaloper1lapm2cq4qjrl4fm5xcftfhg245m63d307y6u7j
+#### Modifications
+# 1. change the chain-id to theta-testnet
+# 2. add tokens to the hy-hydrogen self-delegation account
+
+"""
+  "name" = "hy-hydrogen"
+  "address": "E5C2AF993220B200C1C86E83BBE06A35F960B829",
+  "pub_key": {
+    "type": "tendermint/PubKeyEd25519",
+    "value": "1Lt+cRGXjtRDlQSoQ+DPWj/GNYOzl+0U+7BFAvruu5s="
+  }
+"""
+
+import sys
+import cosmos_genesis_tinker
+
+if len(sys.argv) == 1:
+    print(
+        'Usage: ./genesis-theta.py  [new_genesis.json] [exported_genesis.json]')
+    # sys.exit(1)
+
+exported_genesis_filename = False
+new_genesis_filename = False
+
+if len(sys.argv) > 1:
+    exported_genesis_filename = sys.argv[1]
+if len(sys.argv) > 2:
+    new_genesis_filename = sys.argv[2]
+
+# static values (for now, should be in .json config file)
+NEW_CHAIN_ID = "theta-testnet"
+HYDROGEN_SELF_DELEGATION_ADDR = "cosmos1lapm2cq4qjrl4fm5xcftfhg245m63d30mswfjp"
+HYDROGEN_VAL_OP = "cosmosvaloper1lapm2cq4qjrl4fm5xcftfhg245m63d307y6u7j"
+HYDROGEN_VAL_ADDR = "E5C2AF993220B200C1C86E83BBE06A35F960B829"
+
+GENESIS_ARCHIVE = "./exported_genesis.json"
+GENESIS_SHASUM = "3b541c005dfd79e7286630281422f95465cee8e89f2dce09119bdfb1b61850b0"
+
+UATOM_STAKE_INCREASE = 550000000 * 1000000 
+UATOM_LIQUID_TOKEN_INCREASE = 175000000 * 1000000
+
+THETA_LIQUID_TOKEN_INCREASE = 1000
+RHO_LIQUID_TOKEN_INCREASE = 1000
+LAMBDA_LIQUID_TOKEN_INCREASE = 1000
+EPSILON_LIQUID_TOKEN_INCREASE = 1000
+
+genesis = cosmos_genesis_tinker.GenesisTinker()
+
+if exported_genesis_filename:
+    print("Loading file")
+    genesis.load_file(exported_genesis_filename)
+else:
+    print("Downloading file")
+    genesis.load_url(GENESIS_ARCHIVE, GENESIS_SHASUM)
+
+print("Tinkering")
+
+genesis.swap_chain_id(NEW_CHAIN_ID)
+
+genesis.increase_balance(HYDROGEN_SELF_DELEGATION_ADDR, UATOM_LIQUID_TOKEN_INCREASE)
+genesis.increase_balance(HYDROGEN_SELF_DELEGATION_ADDR, THETA_LIQUID_TOKEN_INCREASE, "theta")
+genesis.increase_balance(HYDROGEN_SELF_DELEGATION_ADDR, RHO_LIQUID_TOKEN_INCREASE, "rho")
+genesis.increase_balance(HYDROGEN_SELF_DELEGATION_ADDR, LAMBDA_LIQUID_TOKEN_INCREASE, "lambda")
+genesis.increase_balance(HYDROGEN_SELF_DELEGATION_ADDR, EPSILON_LIQUID_TOKEN_INCREASE, "epsilon")
+
+genesis.increase_delegator_stake_to_validator(
+    HYDROGEN_SELF_DELEGATION_ADDR, HYDROGEN_VAL_OP, HYDROGEN_VAL_ADDR , UATOM_STAKE_INCREASE)
+
+print("SHA256SUM:")
+print(genesis.generate_shasum())
+
+if new_genesis_filename:
+    print("Saving")
+    genesis.save_file(new_genesis_filename)

--- a/cosmos-genesis-tinker/lint.sh
+++ b/cosmos-genesis-tinker/lint.sh
@@ -1,0 +1,2 @@
+autopep8 --in-place ./*.py
+pylint ./*.py


### PR DESCRIPTION
Adds the initial version of the cosmos genesis tinker script.

This can swap out delegator keys, change balances, increase validator power, and create tokens.

Closes #28 